### PR TITLE
Set the gemspec required_ruby_version

### DIFF
--- a/structured_store.gemspec
+++ b/structured_store.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |spec|
     Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
   end
 
+  spec.required_ruby_version = '>= 3.1.0'
+
   spec.add_dependency 'json_schemer', '~> 2.4'
   spec.add_dependency 'rails', '>= 7.2.2.1'
   spec.add_dependency 'zeitwerk', '~> 2.6'


### PR DESCRIPTION
## What?

I've have set the gemspec required_ruby_version.

## Why?

This silences the last remaining rubocop warning.

## How?

This updates the gemspec to mirror the rubocop TargetRubyVersion.

## Testing?

Rubocop now passes without issue.

## Anything Else?

No.