### PR TITLE
Requiring Rails generator to fix CI testing

### DIFF
--- a/lib/structured_store/generators/install_generator.rb
+++ b/lib/structured_store/generators/install_generator.rb
@@ -1,3 +1,6 @@
+require 'rails/generators'
+require 'rails/generators/base'
+
 module StructuredStore
   module Generators
     # This generator creates a migration for the structured store versioned schemas table


### PR DESCRIPTION
## What?

I've added require statements for the Rails generator `Base` class, so that tests can run properly.

## Why?

As an engine, the tests are not entirely part of a standard rails app, and the explicit requirement is needed when testing in GitHub.

## How?

I've added the require statements.

## Testing?

This PR will test the change.

## Anything Else?

No