### PR TITLE
Non-JSON store columns. Resolves #23 and #24.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,16 +32,29 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-
-    # services:
-    #  redis:
-    #    image: redis
-    #    ports:
-    #      - 6379:6379
-    #    options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_DB: rails_test
+          POSTGRES_USER: rails
+          POSTGRES_PASSWORD: password
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    env:
+      CI: true
+      DATABASE_URL: "postgres://rails:password@localhost:5432/rails_test"
+      RAILS_ENV: test
+      RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
     steps:
       - name: Install packages
-        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y google-chrome-stable curl libjemalloc2 sqlite3
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y google-chrome-stable curl
+        # libjemalloc2
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -51,6 +64,9 @@ jobs:
         with:
           ruby-version: 3.3.5
           bundler-cache: true
+
+      - name: Prepare the database
+        run: bin/rails db:setup
 
       - name: Run tests
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,6 @@
 /log/*.log
 /pkg/
 /tmp/
-/test/dummy/db/*.sqlite3
-/test/dummy/db/*.sqlite3-*
 /test/dummy/log/*.log
 /test/dummy/storage/
 /test/dummy/tmp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Added
+
+- Added tested examples using Binary JSON and non-JSON store columns (vanilla binary and text)
+
 ## [0.1.0]
 
 ### Added

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 
 gem 'puma'
 
-gem 'sqlite3'
+gem 'pg', '~> 1.5'
 
 # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
 gem 'rubocop-rails-omakase', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -233,6 +233,7 @@ GEM
     parser (3.3.8.0)
       ast (~> 2.4.1)
       racc
+    pg (1.5.9)
     pp (0.6.2)
       prettyprint
     prettyprint (0.2.0)
@@ -345,14 +346,6 @@ GEM
     simplecov-html (0.13.1)
     simplecov_json_formatter (0.1.4)
     simpleidn (0.2.3)
-    sqlite3 (2.7.1-aarch64-linux-gnu)
-    sqlite3 (2.7.1-aarch64-linux-musl)
-    sqlite3 (2.7.1-arm-linux-gnu)
-    sqlite3 (2.7.1-arm-linux-musl)
-    sqlite3 (2.7.1-arm64-darwin)
-    sqlite3 (2.7.1-x86_64-darwin)
-    sqlite3 (2.7.1-x86_64-linux-gnu)
-    sqlite3 (2.7.1-x86_64-linux-musl)
     stringio (3.1.7)
     thor (1.3.2)
     timeout (0.4.3)
@@ -386,12 +379,12 @@ DEPENDENCIES
   chronic (~> 0.10.2)
   mocha (~> 2.1)
   ndr_dev_support (~> 7.3)
+  pg (~> 1.5)
   puma
   rake (~> 13.3)
   rubocop (~> 1.77)
   rubocop-rails-omakase
   simplecov (~> 0.22.0)
-  sqlite3
   structured_store!
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -147,6 +147,17 @@ preference.update!(theme: "light", notifications: true)
 preference.store # => {"theme"=>"light", "notifications"=>true, "language"=>"es"}
 ```
 
+If you chose to alter the migration to use a column type other that `json` or `jsonb`, you will need to amend your model to define the store and JSON serialiser (aka coder):
+
+```ruby
+# app/models/user_preference.rb
+class UserPreference < ApplicationRecord
+  include StructuredStore::Storable
+
+  store :store, coder: JSON
+end
+```
+
 ### 4. Schema Versioning
 
 StructuredStore supports schema evolution. You can create new versions of your schema by adding new JSON files and creating migrations to install them.

--- a/test/dummy/app/models/binary_json_store_record.rb
+++ b/test/dummy/app/models/binary_json_store_record.rb
@@ -1,0 +1,3 @@
+class BinaryJsonStoreRecord < ApplicationRecord
+  include StructuredStore::Storable
+end

--- a/test/dummy/app/models/binary_store_record.rb
+++ b/test/dummy/app/models/binary_store_record.rb
@@ -1,0 +1,5 @@
+class BinaryStoreRecord < ApplicationRecord
+  include StructuredStore::Storable
+
+  store :store, coder: JSON
+end

--- a/test/dummy/app/models/text_store_record.rb
+++ b/test/dummy/app/models/text_store_record.rb
@@ -1,0 +1,5 @@
+class TextStoreRecord < ApplicationRecord
+  include StructuredStore::Storable
+
+  store :store, coder: JSON
+end

--- a/test/dummy/config/database.yml
+++ b/test/dummy/config/database.yml
@@ -1,33 +1,95 @@
 ---
-# SQLite. Versions 3.8.0 and up are supported.
-#   gem install sqlite3
+# PostgreSQL. Versions 9.3 and up are supported.
 #
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem "sqlite3"
+# Install the pg driver:
+#   gem install pg
+# On macOS with Homebrew:
+#   gem install pg -- --with-pg-config=/usr/local/bin/pg_config
+# On macOS with MacPorts:
+#   gem install pg -- --with-pg-config=/opt/local/lib/postgresql84/bin/pg_config
+# On Windows:
+#   gem install pg
+#       Choose the win32 build.
+#       Install PostgreSQL and put its /bin directory on your path.
+#
+# Configure Using Gemfile
+# gem "pg"
 #
 default: &default
-  adapter: sqlite3
+  adapter: postgresql
+  encoding: unicode
+  # For details on connection pooling, see Rails configuration guide
+  # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  timeout: 5000
 
 development:
   <<: *default
-  database: storage/development.sqlite3
+  database: structured_store_development
+  host: localhost
+  port: 5432
+
+  # The specified database role being used to connect to postgres.
+  # To create additional roles in postgres see `$ createuser --help`.
+  # When left blank, postgres will use the default role. This is
+  # the same name as the operating system user running Rails.
+  # username: structured_store
+
+  # The password associated with the postgres role (username).
+  # password:
+
+  # Connect on a TCP socket. Omitted by default since the client uses a
+  # domain socket that doesn't need configuration. Windows does not have
+  # domain sockets, so uncomment these lines.
+  # host: localhost
+
+  # The TCP port the server listens on. Defaults to 5432.
+  # If your server runs on a different port number, change accordingly.
+  # port: 5432
+
+  # Schema search path. The server defaults to $user,public
+  # schema_search_path: myapp,sharedapp,public
+
+  # Minimum log levels, in increasing order:
+  #   debug5, debug4, debug3, debug2, debug1,
+  #   log, notice, warning, error, fatal, and panic
+  # Defaults to warning.
+  # min_messages: notice
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
+<% if ENV.fetch('CI', false) %>
 test:
   <<: *default
-  database: storage/test.sqlite3
+  url: <%= ENV["DATABASE_URL"] %>
+<% else %>
+test:
+  <<: *default
+  database: structured_store_test
+  host: localhost
+  port: 5432
+<% end %>
 
-
-# SQLite3 write its data on the local filesystem, as such it requires
-# persistent disks. If you are deploying to a managed service, you should
-# make sure it provides disk persistence, as many don't.
+# As with config/credentials.yml, you never want to store sensitive information,
+# like your database password, in your source code. If your source code is
+# ever seen by anyone, they now have access to your database.
 #
-# Similarly, if you deploy your application as a Docker container, you must
-# ensure the database is located in a persisted volume.
+# Instead, provide the password or a full connection URL as an environment
+# variable when you boot the app. For example:
+#
+#   DATABASE_URL="postgres://myuser:mypass@localhost/somedatabase"
+#
+# If the connection URL is provided in the special DATABASE_URL environment
+# variable, Rails will automatically merge its configuration values on top of
+# the values provided in this file. Alternatively, you can specify a connection
+# URL environment variable explicitly:
+#
+#   production:
+#     url: <%= ENV["MY_APP_DATABASE_URL"] %>
+#
+# Read https://guides.rubyonrails.org/configuring.html#configuring-a-database
+# for a full overview on how database connection configuration can be specified.
+#
 production:
   <<: *default
-  # database: path/to/persistent/storage/production.sqlite3
+  url: <%= ENV["DATABASE_URL"] %>

--- a/test/dummy/db/migrate/20250530080001_create_structured_store.rb
+++ b/test/dummy/db/migrate/20250530080001_create_structured_store.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # This migration creates the underlying table for the structured store
-class CreateStructuredStore < ActiveRecord::Migration[8.0]
+class CreateStructuredStore < ActiveRecord::Migration[7.2]
   def change
     create_table :structured_store_versioned_schemas do |t|
       t.string :name, null: false

--- a/test/dummy/db/migrate/20250530114142_create_store_records.rb
+++ b/test/dummy/db/migrate/20250530114142_create_store_records.rb
@@ -1,4 +1,4 @@
-class CreateStoreRecords < ActiveRecord::Migration[8.0]
+class CreateStoreRecords < ActiveRecord::Migration[7.2]
   def change
     create_table :store_records do |t|
       t.references :structured_store_versioned_schema, null: false, foreign_key: true,

--- a/test/dummy/db/migrate/20250709170436_create_other_store_records.rb
+++ b/test/dummy/db/migrate/20250709170436_create_other_store_records.rb
@@ -1,0 +1,27 @@
+class CreateOtherStoreRecords < ActiveRecord::Migration[7.2]
+  def change
+    create_table :binary_json_store_records do |t|
+      t.references :structured_store_versioned_schema, null: false, foreign_key: true,
+                                                       index: { name: 'index_jsonb_ss_records_on_versioned_schema_id' }
+      t.jsonb :store
+
+      t.timestamps
+    end
+
+    create_table :binary_store_records do |t|
+      t.references :structured_store_versioned_schema, null: false, foreign_key: true,
+                                                       index: { name: 'index_bin_ss_records_on_versioned_schema_id' }
+      t.binary :store
+
+      t.timestamps
+    end
+
+    create_table :text_store_records do |t|
+      t.references :structured_store_versioned_schema, null: false, foreign_key: true,
+                                                       index: { name: 'index_text_records_on_versioned_schema_id' }
+      t.text :store
+
+      t.timestamps
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,9 +10,28 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_30_114142) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_09_170436) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "binary_json_store_records", force: :cascade do |t|
+    t.bigint "structured_store_versioned_schema_id", null: false
+    t.jsonb "store"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["structured_store_versioned_schema_id"], name: "index_jsonb_ss_records_on_versioned_schema_id"
+  end
+
+  create_table "binary_store_records", force: :cascade do |t|
+    t.bigint "structured_store_versioned_schema_id", null: false
+    t.binary "store"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["structured_store_versioned_schema_id"], name: "index_bin_ss_records_on_versioned_schema_id"
+  end
+
   create_table "store_records", force: :cascade do |t|
-    t.integer "structured_store_versioned_schema_id", null: false
+    t.bigint "structured_store_versioned_schema_id", null: false
     t.json "store"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -28,5 +47,16 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_30_114142) do
     t.index ["name", "version"], name: "index_structured_store_versioned_schemas_on_name_and_version", unique: true
   end
 
+  create_table "text_store_records", force: :cascade do |t|
+    t.bigint "structured_store_versioned_schema_id", null: false
+    t.text "store"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["structured_store_versioned_schema_id"], name: "index_text_records_on_versioned_schema_id"
+  end
+
+  add_foreign_key "binary_json_store_records", "structured_store_versioned_schemas"
+  add_foreign_key "binary_store_records", "structured_store_versioned_schemas"
   add_foreign_key "store_records", "structured_store_versioned_schemas"
+  add_foreign_key "text_store_records", "structured_store_versioned_schemas"
 end

--- a/test/dummy/test/fixtures/binary_json_store_records.yml
+++ b/test/dummy/test/fixtures/binary_json_store_records.yml
@@ -1,0 +1,10 @@
+---
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  versioned_schema: demo
+  store:
+
+two:
+  versioned_schema: demo
+  store:

--- a/test/dummy/test/fixtures/binary_store_records.yml
+++ b/test/dummy/test/fixtures/binary_store_records.yml
@@ -1,0 +1,10 @@
+---
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  versioned_schema: demo
+  store:
+
+two:
+  versioned_schema: demo
+  store:

--- a/test/dummy/test/fixtures/text_store_records.yml
+++ b/test/dummy/test/fixtures/text_store_records.yml
@@ -1,0 +1,10 @@
+---
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  versioned_schema: demo
+  store:
+
+two:
+  versioned_schema: demo
+  store:

--- a/test/dummy/test/helpers/store_accessor_test_helper.rb
+++ b/test/dummy/test/helpers/store_accessor_test_helper.rb
@@ -1,0 +1,51 @@
+module StoreAccessorTestHelper
+  def test_define_store_accessors
+    record = klass.new(versioned_schema: total_count_versioned_schema)
+
+    assert record.respond_to?(:theme)
+    assert record.respond_to?(:theme=)
+    record.theme = 'Disco'
+
+    assert record.respond_to?(:total_count)
+    assert record.respond_to?(:total_count=)
+    record.total_count = 42
+
+    record.save!
+
+    record = klass.find(record.id)
+
+    assert record.respond_to?(:theme)
+    assert record.respond_to?(:theme=)
+    assert_equal 'Disco', record.theme
+
+    assert record.respond_to?(:total_count)
+    assert record.respond_to?(:total_count=)
+    assert_equal 42, record.total_count
+  end
+
+  private
+
+  def total_count_versioned_schema
+    versioned_schema = StructuredStore::VersionedSchema.new(name: 'Party', version: '0.10.0')
+
+    versioned_schema.json_schema = <<~STR
+      {
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "type": "object",
+        "properties": {
+          "theme": {
+            "type": "string"
+          },
+          "total_count": {
+            "type": "integer"
+          }
+        },
+        "required": [],
+        "additionalProperties": false
+      }
+    STR
+
+    versioned_schema.save!
+    versioned_schema
+  end
+end

--- a/test/dummy/test/models/binary_json_store_record_test.rb
+++ b/test/dummy/test/models/binary_json_store_record_test.rb
@@ -1,13 +1,12 @@
 require_relative '../../../test_helper'
 require_relative '../helpers/store_accessor_test_helper'
 
-# This tests the StoreRecord model
-class StoreRecordTest < ActiveSupport::TestCase
+class BinaryJsonStoreRecordTest < ActiveSupport::TestCase
   include StoreAccessorTestHelper
 
   private
 
   def klass
-    ::StoreRecord
+    ::BinaryJsonStoreRecord
   end
 end

--- a/test/dummy/test/models/binary_store_record_test.rb
+++ b/test/dummy/test/models/binary_store_record_test.rb
@@ -1,13 +1,12 @@
 require_relative '../../../test_helper'
 require_relative '../helpers/store_accessor_test_helper'
 
-# This tests the StoreRecord model
-class StoreRecordTest < ActiveSupport::TestCase
+class BinaryStoreRecordTest < ActiveSupport::TestCase
   include StoreAccessorTestHelper
 
   private
 
   def klass
-    ::StoreRecord
+    ::BinaryStoreRecord
   end
 end

--- a/test/dummy/test/models/text_store_record_test.rb
+++ b/test/dummy/test/models/text_store_record_test.rb
@@ -1,13 +1,12 @@
 require_relative '../../../test_helper'
 require_relative '../helpers/store_accessor_test_helper'
 
-# This tests the StoreRecord model
-class StoreRecordTest < ActiveSupport::TestCase
+class TextStoreRecordTest < ActiveSupport::TestCase
   include StoreAccessorTestHelper
 
   private
 
   def klass
-    ::StoreRecord
+    ::TextStoreRecord
   end
 end


### PR DESCRIPTION
## What?

I've demonstrated that the StructuredStore can also be used with binary, text and binary JSON columns.

## Why?

Not all databases support JSON columns and so it is useful to show that it is possible with other store column types.

## How?

I created new `<type>StoreRecord` models with the single line added to them to show they can work. I also DRYed up the define_store_accessors test across the (now) 4 models.

## Testing?

The tests now demonstrate that accessors are defined and can persist and retrieve data from the store column.

## Anything Else?

No