### PR TITLE
Added support for JSON schema properties with `type: "array"`

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,12 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(bin/rails test:*)",
+      "Bash(bin/rails:*)",
+      "Bash(bundle exec ruby:*)",
+      "Bash(bundle exec rake test:*)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added tested examples using Binary JSON and non-JSON store columns (vanilla binary and text)
 - The Rails JSON Schema validator can now call a lambda schema
+- Support for JSON schema properties with `type: "array"` with support for `$ref`, `string`, `integer` and `boolean` items
 
 ### Changed
 
 - The structured_store column is now explicitly named to allow for alternative store names and multiple stores per record
+- `BlankRefResolver` now handles array types in addition to scalar types
+- Refactored resolver constructor interface for cleaner architecture
+- Registry methods simplified with cleaner separation of concerns
 
 ## [0.1.0]
 

--- a/README.md
+++ b/README.md
@@ -438,19 +438,36 @@ StructuredStore includes a resolver system for handling JSON schema references. 
 ```ruby
 class CustomResolver < StructuredStore::RefResolvers::Base
   def self.matching_ref_pattern
-    /^#\/custom\//
+    /^external:\/\/my_custom_type\//
   end
 
   def define_attribute
-    lambda do |instance|
-      # Define custom attribute behavior
+    # Access property_schema to get the property's JSON schema
+    type = property_schema['type']
+
+    lambda do |object|
+      # Define custom attribute behavior on the object
+      object.singleton_class.attribute(property_name, type.to_sym)
     end
+  end
+
+  def options_array
+    # Return array of [value, label] pairs for form selects
+    # Access parent_schema.definition_schema(name) if you need to look up definitions
+    []
   end
 end
 
 # Register your custom resolver
 CustomResolver.register
 ```
+
+**Available instance variables in your resolver:**
+- `property_schema` - The property's JSON schema hash
+- `parent_schema` - The parent SchemaInspector for looking up definitions
+- `property_name` - The property name (for error messages)
+- `ref_string` - The `$ref` value
+- `context` - Additional context hash
 
 ### Best Practices
 

--- a/README.md
+++ b/README.md
@@ -245,7 +245,85 @@ preference.valid? # => true
 preference.notifications = "invalid" # Will cause validation error
 ```
 
-### 6. Working with Complex Data Types
+### 6. Working with Array Properties
+
+StructuredStore supports JSON schema properties with `type: "array"` for both arrays with `$ref` items and arrays with direct type items.
+
+#### Arrays with Direct Type Items
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "type": "object",
+  "properties": {
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "List of tags"
+    }
+  }
+}
+```
+
+```ruby
+schema = StructuredStore::VersionedSchema.create!(
+  name: 'BlogPost',
+  version: '1.0.0',
+  json_schema: schema
+)
+
+post = BlogPost.new(data_versioned_schema: schema)
+post.tags = ['ruby', 'rails', 'testing']
+post.save!
+
+post.tags # => ['ruby', 'rails', 'testing']
+```
+
+#### Arrays with $ref Items
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "type": "object",
+  "definitions": {
+    "status_type": {
+      "type": "string",
+      "enum": ["pending", "active", "completed"]
+    }
+  },
+  "properties": {
+    "statuses": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/status_type"
+      },
+      "description": "List of statuses"
+    }
+  }
+}
+```
+
+```ruby
+schema = StructuredStore::VersionedSchema.create!(
+  name: 'Workflow',
+  version: '1.0.0',
+  json_schema: schema
+)
+
+workflow = Workflow.new(data_versioned_schema: schema)
+workflow.statuses = ['pending', 'active']
+workflow.save!
+
+workflow.statuses # => ['pending', 'active']
+```
+
+**Supported item types:** `string`, `integer`, `boolean`
+
+**Note:** Arrays with `object` or other complex item types are not currently supported.
+
+### 7. Working with Complex Data Types
 
 StructuredStore includes a `JsonDateRangeResolver` for handling date ranges through JSON schema references. This resolver works with date range converters to transform natural language date strings into structured date ranges.
 
@@ -333,7 +411,7 @@ class MyModel < ApplicationRecord
 end
 ```
 
-### 7. Finding and Querying Schemas
+### 8. Finding and Querying Schemas
 
 ```ruby
 # Find the latest version of a schema
@@ -347,13 +425,13 @@ all_versions = StructuredStore::VersionedSchema.where(name: "UserPreferences")
                                                .order(:version)
 ```
 
-### 8. Configurable Store Columns
+### 9. Configurable Store Columns
 
 StructuredStore supports configurable store columns, allowing you to use alternative column names for a single store (e.g., `depot` instead of `store`) or configure multiple store columns within the same model. This enables you to organize different types of structured data separately while maintaining proper schema versioning.
 
 For detailed information on configuring single custom stores and multiple stores, see the [Custom Stores documentation](docs/custom_stores.md).
 
-### 9. Advanced Usage: Custom Reference Resolvers
+### 10. Advanced Usage: Custom Reference Resolvers
 
 StructuredStore includes a resolver system for handling JSON schema references. You can create custom resolvers by extending `StructuredStore::RefResolvers::Base`:
 

--- a/lib/structured_store/ref_resolvers/base.rb
+++ b/lib/structured_store/ref_resolvers/base.rb
@@ -7,7 +7,8 @@ module StructuredStore
       attr_reader :context,
                   :property_name,
                   :ref_string,
-                  :schema_inspector
+                  :property_schema,
+                  :parent_schema
 
       class << self
         def matching_ref_pattern
@@ -25,10 +26,14 @@ module StructuredStore
 
       # Initialize method for the base reference resolver
       #
-      # @param schema [Hash] JSON Schema for the resolver
-      # @param options [Hash] Additional options for the resolver
-      def initialize(schema_inspector, property_name, ref_string, context = {})
-        @schema_inspector = schema_inspector
+      # @param property_schema [Hash] The property's JSON schema (with type, $ref, etc.)
+      # @param parent_schema [SchemaInspector] Parent schema for definition lookups
+      # @param property_name [String] Name of the property (for error messages)
+      # @param ref_string [String] The $ref string if present
+      # @param context [Hash] Additional context
+      def initialize(property_schema, parent_schema, property_name, ref_string = '', context = {})
+        @property_schema = property_schema
+        @parent_schema = parent_schema
         @property_name = property_name
         @ref_string = ref_string
         @context = context
@@ -53,12 +58,6 @@ module StructuredStore
       # @raise [NotImplementedError] if the method is not implemented by a subclass
       def options_array
         raise NotImplementedError, 'Subclasses must implement the options_array method'
-      end
-
-      private
-
-      def json_property_schema
-        @json_property_schema ||= schema_inspector.property_schema(property_name) || {}
       end
     end
   end

--- a/lib/structured_store/ref_resolvers/blank_ref_resolver.rb
+++ b/lib/structured_store/ref_resolvers/blank_ref_resolver.rb
@@ -85,7 +85,7 @@ module StructuredStore
         items_ref = items_schema['$ref'].to_s
 
         # Use the registry to create a resolver for the items schema
-        Registry.resolver_for_schema_hash(items_schema, items_ref, parent_schema, property_name, context)
+        Registry.resolver_for_schema_hash(items_schema, parent_schema, property_name, items_ref, context)
       end
     end
 

--- a/lib/structured_store/ref_resolvers/definitions_resolver.rb
+++ b/lib/structured_store/ref_resolvers/definitions_resolver.rb
@@ -53,7 +53,7 @@ module StructuredStore
       #   resolver.local_definition  # => { "type" => "string" }
       def local_definition
         definition_name = ref_string.sub('#/definitions/', '')
-        local_definition = schema_inspector.definition_schema(definition_name)
+        local_definition = parent_schema.definition_schema(definition_name)
 
         raise "No definition for #{ref_string}" if local_definition.nil?
 

--- a/lib/structured_store/ref_resolvers/definitions_resolver.rb
+++ b/lib/structured_store/ref_resolvers/definitions_resolver.rb
@@ -12,10 +12,6 @@ module StructuredStore
         %r{\A#/definitions/}
       end
 
-      def initialize(schema, property_name, ref_string, context = {})
-        super
-      end
-
       # Defines the rails attribute(s) on the given singleton class
       #
       # @return [Proc] a lambda that defines the attribute on the singleton class

--- a/lib/structured_store/ref_resolvers/registry.rb
+++ b/lib/structured_store/ref_resolvers/registry.rb
@@ -31,15 +31,31 @@ module StructuredStore
 
         # Returns a resolver instance for the given schema property reference
         #
-        # @param [Hash] schema The JSON schema containing the property reference
+        # @param [SchemaInspector] schema_inspector The JSON schema inspector
         # @param [String, Symbol] property_name The name of the property containing the reference
         # @param [Hash] context Optional context hash (default: {})
         # @return [RefResolver] An instance of the appropriate resolver class for the reference
         # @raise [RuntimeError] If no matching resolver can be found for the reference
         def matching_resolver(schema_inspector, property_name, context = {})
-          ref_string = schema_inspector.property_schema(property_name)['$ref']
+          property_schema = schema_inspector.property_schema(property_name)
+          ref_string = property_schema['$ref'].to_s
 
-          klass_factory(ref_string).new(schema_inspector, property_name, ref_string, context)
+          klass = klass_factory(ref_string)
+          klass.new(property_schema, schema_inspector, property_name, ref_string, context)
+        end
+
+        # Returns a resolver instance for a schema hash (e.g., array items)
+        # Direct method that doesn't require looking up properties
+        #
+        # @param [Hash] schema_hash The schema hash (with potential $ref)
+        # @param [String] ref_string The $ref string
+        # @param [SchemaInspector] parent_schema Parent schema for definition lookups
+        # @param [String] property_name The property name for error messages
+        # @param [Hash] context Optional context hash (default: {})
+        # @return [RefResolver] An instance of the appropriate resolver class
+        def resolver_for_schema_hash(schema_hash, ref_string, parent_schema, property_name, context = {})
+          klass = klass_factory(ref_string)
+          klass.new(schema_hash, parent_schema, property_name, ref_string, context)
         end
 
         private

--- a/lib/structured_store/ref_resolvers/registry.rb
+++ b/lib/structured_store/ref_resolvers/registry.rb
@@ -40,20 +40,19 @@ module StructuredStore
           property_schema = schema_inspector.property_schema(property_name)
           ref_string = property_schema['$ref'].to_s
 
-          klass = klass_factory(ref_string)
-          klass.new(property_schema, schema_inspector, property_name, ref_string, context)
+          resolver_for_schema_hash(property_schema, schema_inspector, property_name, ref_string, context)
         end
 
         # Returns a resolver instance for a schema hash (e.g., array items)
         # Direct method that doesn't require looking up properties
         #
         # @param [Hash] schema_hash The schema hash (with potential $ref)
-        # @param [String] ref_string The $ref string
         # @param [SchemaInspector] parent_schema Parent schema for definition lookups
         # @param [String] property_name The property name for error messages
+        # @param [String] ref_string The $ref string
         # @param [Hash] context Optional context hash (default: {})
         # @return [RefResolver] An instance of the appropriate resolver class
-        def resolver_for_schema_hash(schema_hash, ref_string, parent_schema, property_name, context = {})
+        def resolver_for_schema_hash(schema_hash, parent_schema, property_name, ref_string, context = {})
           klass = klass_factory(ref_string)
           klass.new(schema_hash, parent_schema, property_name, ref_string, context)
         end

--- a/test/dummy/lib/custom_lookup_resolver.rb
+++ b/test/dummy/lib/custom_lookup_resolver.rb
@@ -21,7 +21,7 @@ class CustomLookupResolver < StructuredStore::RefResolvers::Base
   def define_attribute
     # You could hard-code the type if it were always the same,
     # but it makes the JSON schema more declarative
-    type = json_property_schema['type']
+    type = property_schema['type']
 
     unless %w[boolean integer string].include?(type)
       raise "Unsupported attribute type: #{type.inspect} for property '#{property_name}'"

--- a/test/ref_resolvers/blank_ref_resolver_test.rb
+++ b/test/ref_resolvers/blank_ref_resolver_test.rb
@@ -51,6 +51,165 @@ module StructuredStore
 
         assert_equal [%w[option1 option1], %w[option2 option2], %w[option3 option3]], resolver.options_array
       end
+
+      test 'array with direct type items (string)' do
+        schema = {
+          '$schema' => 'https://json-schema.org/draft/2019-09/schema',
+          'type' => 'object',
+          'properties' => {
+            'tags' => {
+              'type' => 'array',
+              'items' => {
+                'type' => 'string'
+              }
+            }
+          }
+        }
+
+        versioned_schema = VersionedSchema.new(json_schema: schema)
+        store_record = StoreRecord.new(store_versioned_schema: versioned_schema)
+
+        assert_respond_to store_record, :tags
+        assert_respond_to store_record, :tags=
+
+        store_record.tags = %w[ruby rails testing]
+        assert_equal %w[ruby rails testing], store_record.tags
+      end
+
+      test 'array with direct type items (integer)' do
+        schema = {
+          '$schema' => 'https://json-schema.org/draft/2019-09/schema',
+          'type' => 'object',
+          'properties' => {
+            'scores' => {
+              'type' => 'array',
+              'items' => {
+                'type' => 'integer'
+              }
+            }
+          }
+        }
+
+        versioned_schema = VersionedSchema.new(json_schema: schema)
+        store_record = StoreRecord.new(store_versioned_schema: versioned_schema)
+
+        assert_respond_to store_record, :scores
+        assert_respond_to store_record, :scores=
+
+        store_record.scores = [1, 2, 3, 4, 5]
+        assert_equal [1, 2, 3, 4, 5], store_record.scores
+      end
+
+      test 'array with $ref items pointing to definition' do
+        schema = {
+          '$schema' => 'https://json-schema.org/draft/2019-09/schema',
+          'type' => 'object',
+          'definitions' => {
+            'stain_type' => {
+              'type' => 'string',
+              'enum' => %w[A B C]
+            }
+          },
+          'properties' => {
+            'stains' => {
+              'type' => 'array',
+              'items' => {
+                '$ref' => '#/definitions/stain_type'
+              }
+            }
+          }
+        }
+
+        versioned_schema = VersionedSchema.new(json_schema: schema)
+        store_record = StoreRecord.new(store_versioned_schema: versioned_schema)
+
+        assert_respond_to store_record, :stains
+        assert_respond_to store_record, :stains=
+
+        store_record.stains = %w[A B]
+        assert_equal %w[A B], store_record.stains
+      end
+
+      test 'array with $ref items - options_array' do
+        schema = {
+          '$schema' => 'https://json-schema.org/draft/2019-09/schema',
+          'type' => 'object',
+          'definitions' => {
+            'status' => {
+              'type' => 'string',
+              'enum' => %w[pending active completed]
+            }
+          },
+          'properties' => {
+            'statuses' => {
+              'type' => 'array',
+              'items' => {
+                '$ref' => '#/definitions/status'
+              }
+            }
+          }
+        }
+
+        versioned_schema = VersionedSchema.new(json_schema: schema)
+        store_record = StoreRecord.new(store_versioned_schema: versioned_schema)
+
+        resolver = store_record.property_resolvers('store')['statuses']
+        options = resolver.options_array
+
+        assert_equal 3, options.length
+        assert_includes options, %w[pending pending]
+        assert_includes options, %w[active active]
+        assert_includes options, %w[completed completed]
+      end
+
+      test 'array with direct type items with enum - options_array' do
+        schema = {
+          '$schema' => 'https://json-schema.org/draft/2019-09/schema',
+          'type' => 'object',
+          'properties' => {
+            'priorities' => {
+              'type' => 'array',
+              'items' => {
+                'type' => 'string',
+                'enum' => %w[low medium high]
+              }
+            }
+          }
+        }
+
+        versioned_schema = VersionedSchema.new(json_schema: schema)
+        store_record = StoreRecord.new(store_versioned_schema: versioned_schema)
+
+        resolver = store_record.property_resolvers('store')['priorities']
+        options = resolver.options_array
+
+        assert_equal 3, options.length
+        assert_includes options, %w[low low]
+        assert_includes options, %w[medium medium]
+        assert_includes options, %w[high high]
+      end
+
+      test 'array with unsupported item type raises error' do
+        schema = {
+          '$schema' => 'https://json-schema.org/draft/2019-09/schema',
+          'type' => 'object',
+          'properties' => {
+            'complex_items' => {
+              'type' => 'array',
+              'items' => {
+                'type' => 'object'
+              }
+            }
+          }
+        }
+
+        exception = assert_raises(RuntimeError) do
+          versioned_schema = VersionedSchema.new(json_schema: schema)
+          StoreRecord.new(store_versioned_schema: versioned_schema)
+        end
+
+        assert_equal 'Unsupported array item type: "object" for property \'complex_items\'', exception.message
+      end
     end
   end
 end


### PR DESCRIPTION
## What?

I've added support for for JSON schema properties with `type: "array"`. Items can themselves be `$ref`erences or of type `string`, `integer` or `boolean`.

## Why?

We need to use the Structure Store to hold multiple values for an attribute, esp where those values are from an enum `$ref`.

## How?

This refactors the registry and allows the `BlankRefResolver` to re-use the registry for item definitions.

## Testing?

All tests pass.

## Anything Else?

This is a big breaking change so we should consider bumping to v1 after merging this.